### PR TITLE
Update furiosa sdk installation link to latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # optimum-furiosa
-Accelerated inference of 🤗 models using FuriosaAI NPU chips. 
+Accelerated inference of 🤗 models using FuriosaAI NPU chips.
 
 ## Furiosa SDK setup
-A Furiosa SDK environment needs to be enabled to use this library. Please refer to Furiosa's [Installation](https://furiosa-ai.github.io/docs/v0.5.0/en/installation/prerequisites.html#) guide.
+A Furiosa SDK environment needs to be enabled to use this library. Please refer to Furiosa's [Installation](https://furiosa-ai.github.io/docs/latest/en/software/installation.html) guide.
 
 ## Install
 Optimum Furiosa is a fast-moving project, and you may want to install from source.


### PR DESCRIPTION
The current installation link in README.md is outdated (it's 0.5.0)
Update the link to point latest(0.9.0 ) installation link